### PR TITLE
ensure -o argument value is valid

### DIFF
--- a/fontMakeExport.glyphsFileFormat/Contents/Resources/plugin.py
+++ b/fontMakeExport.glyphsFileFormat/Contents/Resources/plugin.py
@@ -230,12 +230,17 @@ class FontMakeExport(FileFormatPlugin):
 		outlineformat = Glyphs.intDefaults[ExportOutlineformatKey]
 		outlineformatKey = outlineformatKeys[outlineformat]
 		additionalOptions = Glyphs.defaults[AdditionalOptionsKey]
-		master_dir = os.path.join(tempFolder, "masters")
 
 		arguments = [
-			venvPythonPath, "-m", "fontmake", "--output-dir", exportPath, "--master-dir",
-			os.path.join(exportPath, "masters"), "--instance-dir",
-			os.path.join(exportPath, "instances"), "-g", tempFile, "-o", *outlineformatKey
+			venvPythonPath,
+			"-m",
+			"fontmake",
+			"--output-dir",
+			exportPath,
+			"-g",
+			tempFile,
+			"-o",
+			*outlineformatKey,
 		]
 		if additionalOptions:
 			additionalOptions = additionalOptions.split(" ")

--- a/fontMakeExport.glyphsFileFormat/Contents/Resources/plugin.py
+++ b/fontMakeExport.glyphsFileFormat/Contents/Resources/plugin.py
@@ -37,8 +37,8 @@ OutlineFormatStaticCFF = 3
 OutlineFormatStaticTTF = 4
 
 outlineformatKeys = {
-	OutlineFormatVariableTTF: ("variable"),
-	OutlineFormatVariableCFF: ("variable-cff2"),
+	OutlineFormatVariableTTF: ("variable", ),
+	OutlineFormatVariableCFF: ("variable-cff2", ),
 	OutlineFormatStaticCFF: ("otf", "-i"),
 	OutlineFormatStaticTTF: ("ttf", "-i"),
 }


### PR DESCRIPTION
your outlineFormatKeys is supposed to contain tuples, a single item tuple still needs a comma at the end, otherwise the parentheses are ignored, you do *outlineFormatKey later on, which basically unpacks the string itself into its individual characters, instead of upacking the tuple that contains the string...

without this fix, I get:
error: argument -o/--output: invalid choice

and I can see in the __arguments list printed in the Macro panel that it tries to pass '-o', 'v', 'a', 'r', 'i', 'a', 'b', 'l', 'e'

Have you actually tried to run this? ;)