### PR TITLE
set suprocess encoding to utf-8 to fix UnicodeDecodeError: ascii...

### DIFF
--- a/fontMakeExport.glyphsFileFormat/Contents/Resources/plugin.py
+++ b/fontMakeExport.glyphsFileFormat/Contents/Resources/plugin.py
@@ -63,6 +63,7 @@ def run_subprocess_in_macro_window(command, check=False, show_window=True, captu
 		command,
 		stdout=subprocess.PIPE,
 		stderr=subprocess.STDOUT,  # Redirect stderr to stdout
+		encoding="utf-8",
 		text=True,
 		bufsize=1,  # Line-buffered
 	)


### PR DESCRIPTION
I just tried to update the embedded fontmake and it failed with some UnicodeDecodeError complaining about non-ascii characters, so it's better to set the UTF-8 encoding explicitly when reading from the subprocess output